### PR TITLE
Add/#29 사용자 피드백 반영 스티커 회전 버그 수정, 구글 애드몹 추가, 필터 추가, 펜툴 추가

### DIFF
--- a/app.json
+++ b/app.json
@@ -22,7 +22,7 @@
       "edgeToEdgeEnabled": true,
       "package": "com.leesuyoen.purisnapapp",
       "runtimeVersion": "1.1.2",
-      "versionCode": 5
+      "versionCode": 6
     },
     "web": {
       "bundler": "metro",
@@ -38,6 +38,13 @@
           "imageWidth": 200,
           "resizeMode": "contain",
           "backgroundColor": "#ffdce6"
+        }
+      ],
+      [
+        "react-native-google-mobile-ads",
+        {
+          "androidAppId": "ca-app-pub-5067038499285963~4579815970",
+          "iosAppId": "ca-app-pub-3940256099942544~1458002511"
         }
       ]
     ],

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "purisnap",
     "slug": "purikura",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "purisnap",
@@ -21,8 +21,8 @@
       },
       "edgeToEdgeEnabled": true,
       "package": "com.leesuyoen.purisnapapp",
-      "runtimeVersion": "1.1.2",
-      "versionCode": 6
+      "runtimeVersion": "1.2.0",
+      "versionCode": 7
     },
     "web": {
       "bundler": "metro",

--- a/components/ui/bridge/customCropScreen.tsx
+++ b/components/ui/bridge/customCropScreen.tsx
@@ -2,7 +2,15 @@ import { useImageStore } from "@/store/useImageStore";
 import { MaterialIcons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import React, { useRef, useState } from "react";
-import { Dimensions, Text, TouchableOpacity, View } from "react-native";
+import {
+  ActivityIndicator,
+  Alert,
+  Dimensions,
+  Platform,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import {
   Gesture,
   GestureDetector,
@@ -33,6 +41,7 @@ export function CustomCropScreen() {
   const flipY = useSharedValue(1);
 
   const [aspectRatio, setAspectRatio] = useState({ width: 3, height: 4 });
+  const [isRemovingBg, setIsRemovingBg] = useState(false);
 
   const baseScale = useSharedValue(1);
   const pinchScale = useSharedValue(1);
@@ -68,7 +77,11 @@ export function CustomCropScreen() {
   const CROP_HEIGHT = SCREEN_WIDTH * (aspectRatio.height / aspectRatio.width);
 
   const onCapture = async () => {
-    if (viewShotRef.current) {
+    if (Platform.OS === "web") {
+      router.push("/main");
+      return;
+    }
+    if (viewShotRef.current?.capture) {
       const uri = await viewShotRef.current.capture();
       setImageUri(uri);
       router.push("/main");
@@ -96,6 +109,66 @@ export function CustomCropScreen() {
 
   const flipVertically = () => {
     flipY.value = withTiming(flipY.value === 1 ? -1 : 1);
+  };
+
+  const removeBackground = async () => {
+    if (!imageUri || isRemovingBg) return;
+
+    const apiKey = process.env.EXPO_PUBLIC_REMOVE_BG_API_KEY;
+    if (!apiKey) {
+      Alert.alert("API 키 없음", "EXPO_PUBLIC_REMOVE_BG_API_KEY를 설정하세요.");
+      return;
+    }
+
+    try {
+      setIsRemovingBg(true);
+
+      const formData = new FormData();
+      if (Platform.OS === "web") {
+        const blob = await (await fetch(imageUri)).blob();
+        formData.append("image_file", blob, "image.png");
+      } else {
+        formData.append("image_file", {
+          uri: imageUri,
+          name: "image.png",
+          type: "image/png",
+        } as any);
+      }
+      formData.append("size", __DEV__ ? "preview" : "auto");
+
+      const res = await fetch("https://api.remove.bg/v1.0/removebg", {
+        method: "POST",
+        headers: { "X-Api-Key": apiKey },
+        body: formData,
+      });
+
+      if (!res.ok) {
+        console.warn("[removeBg] failed", res.status, await res.text());
+        Alert.alert(
+          "알림",
+          "해당 기능은 현재 이용할 수 없습니다.\n잠시 후 다시 시도해 주세요."
+        );
+        return;
+      }
+
+      const blob = await res.blob();
+      const dataUri = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result as string);
+        reader.onerror = reject;
+        reader.readAsDataURL(blob);
+      });
+
+      setImageUri(dataUri);
+    } catch (e) {
+      console.warn("[removeBg] error", e);
+      Alert.alert(
+        "알림",
+        "해당 기능은 현재 이용할 수 없습니다.\n잠시 후 다시 시도해 주세요."
+      );
+    } finally {
+      setIsRemovingBg(false);
+    }
   };
 
   const toggleAspectRatio = () => {
@@ -140,6 +213,25 @@ export function CustomCropScreen() {
             />
           </GestureDetector>
         </ViewShot>
+        {isRemovingBg && (
+          <View
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              backgroundColor: "rgba(0,0,0,0.5)",
+              justifyContent: "center",
+              alignItems: "center",
+            }}
+          >
+            <ActivityIndicator size="large" color="white" />
+            <Text style={{ color: "white", marginTop: 8 }}>
+              배경 제거 중...
+            </Text>
+          </View>
+        )}
       </View>
 
       {/* 하단 툴바 */}
@@ -183,6 +275,18 @@ export function CustomCropScreen() {
             size={28}
             color="white"
             style={{ transform: [{ rotate: "90deg" }] }}
+          />
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={removeBackground}
+          disabled={isRemovingBg}
+          testID="remove-bg-button"
+        >
+          <MaterialIcons
+            name="auto-fix-high"
+            size={28}
+            color={isRemovingBg ? "gray" : "white"}
           />
         </TouchableOpacity>
       </View>

--- a/components/ui/common/editorCanvas/DrawingLayer.tsx
+++ b/components/ui/common/editorCanvas/DrawingLayer.tsx
@@ -6,7 +6,13 @@ import React, {
   useRef,
 } from "react";
 import { PanResponder, PanResponderInstance, View } from "react-native";
-import Svg, { Path } from "react-native-svg";
+import Svg, {
+  Circle,
+  Defs,
+  LinearGradient,
+  Path,
+  Stop,
+} from "react-native-svg";
 import styled from "styled-components/native";
 
 const Container = styled.View`
@@ -29,13 +35,116 @@ type DrawingLayerProps = {
   disabled?: boolean;
 };
 
+const parsePathPoints = (commands: string[]) => {
+  const points: { x: number; y: number }[] = [];
+  for (const cmd of commands) {
+    const match = cmd.match(/[ML]([\d.-]+),([\d.-]+)/);
+    if (match) {
+      points.push({ x: parseFloat(match[1]), y: parseFloat(match[2]) });
+    }
+  }
+  return points;
+};
+
+function renderPathItem(item: PathItem, key: string) {
+  const d = item.path.join(" ");
+  const w = item.width;
+
+  if (item.color === "glitter") {
+    const points = parsePathPoints(item.path);
+    return (
+      <React.Fragment key={key}>
+        <Path
+          d={d}
+          stroke="url(#glitterGrad)"
+          strokeWidth={w}
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        {points
+          .filter((_, i) => i % 6 === 0)
+          .map((p, i) => (
+            <Circle
+              key={`${key}-spark-${i}`}
+              cx={p.x}
+              cy={p.y}
+              r={(i % 3) + 2}
+              fill="white"
+              opacity={0.9}
+            />
+          ))}
+      </React.Fragment>
+    );
+  }
+
+  if (item.color === "neon") {
+    const neonColor = "#00FFFF";
+    return (
+      <React.Fragment key={key}>
+        <Path
+          d={d}
+          stroke={neonColor}
+          strokeWidth={w * 3}
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          opacity={0.25}
+        />
+        <Path
+          d={d}
+          stroke={neonColor}
+          strokeWidth={w * 1.8}
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          opacity={0.5}
+        />
+        <Path
+          d={d}
+          stroke="white"
+          strokeWidth={Math.max(w * 0.6, 1)}
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </React.Fragment>
+    );
+  }
+
+  if (item.color === "rainbow") {
+    return (
+      <Path
+        key={key}
+        d={d}
+        stroke="url(#rainbowGrad)"
+        strokeWidth={w}
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    );
+  }
+
+  return (
+    <Path
+      key={key}
+      d={d}
+      stroke={item.color}
+      strokeWidth={w}
+      fill="none"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  );
+}
+
 export const DrawingLayer = forwardRef(function DrawingLayer(
   { currentColor, strokeWidth, disabled = false }: DrawingLayerProps,
   ref
 ) {
   const currentColorRef = useRef(currentColor);
   const strokeWidthRef = useRef(strokeWidth);
-  const panResponderRef = useRef<PanResponderInstance | null>(null);
 
   useEffect(() => {
     currentColorRef.current = currentColor;
@@ -64,6 +173,7 @@ export const DrawingLayer = forwardRef(function DrawingLayer(
       forceUpdate();
     },
   }));
+
   const panResponder = useMemo(() => {
     return PanResponder.create({
       onStartShouldSetPanResponder: () => !disabled,
@@ -104,27 +214,41 @@ export const DrawingLayer = forwardRef(function DrawingLayer(
         {...panResponder.panHandlers}
       >
         <Svg style={{ flex: 1 }}>
-          {pathsRef.current.map((item, idx) => (
-            <Path
-              key={`path-${idx}`}
-              d={item.path.join(" ")}
-              stroke={item.color}
-              strokeWidth={item.width}
-              fill="none"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          ))}
-          {currentPath.current.path.length > 0 && (
-            <Path
-              d={currentPath.current.path.join(" ")}
-              stroke={currentPath.current.color}
-              strokeWidth={currentPath.current.width}
-              fill="none"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
+          <Defs>
+            <LinearGradient
+              id="glitterGrad"
+              x1="0%"
+              y1="0%"
+              x2="100%"
+              y2="100%"
+            >
+              <Stop offset="0%" stopColor="#FF1493" />
+              <Stop offset="25%" stopColor="#FFD700" />
+              <Stop offset="50%" stopColor="#00FFFF" />
+              <Stop offset="75%" stopColor="#9370DB" />
+              <Stop offset="100%" stopColor="#FF00FF" />
+            </LinearGradient>
+            <LinearGradient
+              id="rainbowGrad"
+              x1="0%"
+              y1="0%"
+              x2="100%"
+              y2="100%"
+            >
+              <Stop offset="0%" stopColor="#FF0000" />
+              <Stop offset="16%" stopColor="#FF7F00" />
+              <Stop offset="33%" stopColor="#FFFF00" />
+              <Stop offset="50%" stopColor="#00FF00" />
+              <Stop offset="66%" stopColor="#0000FF" />
+              <Stop offset="83%" stopColor="#4B0082" />
+              <Stop offset="100%" stopColor="#9400D3" />
+            </LinearGradient>
+          </Defs>
+          {pathsRef.current.map((item, idx) =>
+            renderPathItem(item, `committed-${idx}`)
           )}
+          {currentPath.current.path.length > 0 &&
+            renderPathItem(currentPath.current, "current")}
         </Svg>
       </View>
     </Container>

--- a/components/ui/common/editorCanvas/StickerItem.tsx
+++ b/components/ui/common/editorCanvas/StickerItem.tsx
@@ -1,12 +1,12 @@
 import { useEditorStore } from "@/store/useEditorStore";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { useRef } from "react";
 import { PanResponder, Pressable, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
   runOnJS,
   useAnimatedStyle,
   useSharedValue,
-  withTiming,
 } from "react-native-reanimated";
 import styled from "styled-components/native";
 
@@ -56,6 +56,7 @@ type Props = {
   x: number;
   y: number;
   scale: number;
+  rotation: number;
   isSelected: boolean;
   onSelect: (id: string) => void;
 };
@@ -66,20 +67,32 @@ export function StickerItem({
   x,
   y,
   scale,
+  rotation,
   isSelected,
   onSelect,
 }: Props) {
   const updatePosition = useEditorStore((s) => s.updateStickerPosition);
   const updateScale = useEditorStore((s) => s.updateStickerScale);
+  const updateRotation = useEditorStore((s) => s.updateStickerRotation);
   const removeSticker = useEditorStore((s) => s.removeSticker);
 
   const offsetX = useSharedValue(x);
   const offsetY = useSharedValue(y);
   const scaleVal = useSharedValue(scale);
-  const rotationVal = useSharedValue(0);
+  const rotationVal = useSharedValue(rotation);
 
   let startScale = scale;
   let startRotation = 0;
+  let rotateStartVal = 0;
+  let resizeStartVal = scale;
+
+  const stickerViewRef = useRef<View>(null);
+  const rotateState = useRef({
+    centerX: 0,
+    centerY: 0,
+    startAngle: 0,
+    ready: false,
+  });
 
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [
@@ -87,6 +100,13 @@ export function StickerItem({
       { translateY: offsetY.value },
       { scale: scaleVal.value },
       { rotateZ: `${rotationVal.value}rad` },
+    ],
+  }));
+
+  const controlIconCounterStyle = useAnimatedStyle(() => ({
+    transform: [
+      { rotateZ: `${-rotationVal.value}rad` },
+      { scale: 1 / scaleVal.value },
     ],
   }));
 
@@ -118,6 +138,9 @@ export function StickerItem({
     })
     .onUpdate((e) => {
       rotationVal.value = startRotation + e.rotation;
+    })
+    .onEnd(() => {
+      runOnJS(updateRotation)(id, rotationVal.value);
     });
 
   const combinedGesture = Gesture.Simultaneous(
@@ -128,18 +151,44 @@ export function StickerItem({
 
   const handleRotateDrag = PanResponder.create({
     onStartShouldSetPanResponder: () => true,
-    onPanResponderMove: (_, gestureState) => {
-      const rotationAmount = gestureState.dx * 0.01;
-      rotationVal.value = withTiming(rotationVal.value - rotationAmount, {
-        duration: 50,
+    onPanResponderGrant: (e) => {
+      rotateStartVal = rotationVal.value;
+      rotateState.current.ready = false;
+      stickerViewRef.current?.measureInWindow((x, y, width, height) => {
+        const cx = x + width / 2;
+        const cy = y + height / 2;
+        rotateState.current = {
+          centerX: cx,
+          centerY: cy,
+          startAngle: Math.atan2(
+            e.nativeEvent.pageY - cy,
+            e.nativeEvent.pageX - cx
+          ),
+          ready: true,
+        };
       });
+    },
+    onPanResponderMove: (e) => {
+      if (!rotateState.current.ready) return;
+      const { centerX, centerY, startAngle } = rotateState.current;
+      const currentAngle = Math.atan2(
+        e.nativeEvent.pageY - centerY,
+        e.nativeEvent.pageX - centerX
+      );
+      rotationVal.value = rotateStartVal + (currentAngle - startAngle);
+    },
+    onPanResponderRelease: () => {
+      runOnJS(updateRotation)(id, rotationVal.value);
     },
   });
 
   const handleResizeDrag = PanResponder.create({
     onStartShouldSetPanResponder: () => true,
+    onPanResponderGrant: () => {
+      resizeStartVal = scaleVal.value;
+    },
     onPanResponderMove: (_, gestureState) => {
-      const newScale = scaleVal.value + gestureState.dx * 0.003;
+      const newScale = resizeStartVal + gestureState.dx * 0.003;
       scaleVal.value = Math.max(0.3, Math.min(3, newScale));
     },
     onPanResponderRelease: () => {
@@ -149,7 +198,10 @@ export function StickerItem({
 
   return (
     <GestureDetector gesture={combinedGesture}>
-      <Animated.View style={[{ position: "absolute" }, animatedStyle]}>
+      <Animated.View
+        ref={stickerViewRef}
+        style={[{ position: "absolute" }, animatedStyle]}
+      >
         <View style={{ alignItems: "center" }} testID={`sticker-${id}`}>
           <Pressable onPress={() => onSelect(id)}>
             <StickerImage
@@ -170,7 +222,7 @@ export function StickerItem({
               </DeleteButton>
 
               <ControlIcon
-                style={{ bottom: -10, right: -10 }}
+                style={[{ bottom: -10, right: -10 }, controlIconCounterStyle]}
                 {...handleRotateDrag.panHandlers}
                 testID="rotate-icon"
               >
@@ -182,7 +234,7 @@ export function StickerItem({
               </ControlIcon>
 
               <ControlIcon
-                style={{ bottom: -10, left: -10 }}
+                style={[{ bottom: -10, left: -10 }, controlIconCounterStyle]}
                 {...handleResizeDrag.panHandlers}
                 testID="resize-icon"
               >

--- a/components/ui/common/editorCanvas/StickerLayer.tsx
+++ b/components/ui/common/editorCanvas/StickerLayer.tsx
@@ -34,6 +34,7 @@ export const StickerLayer = ({
             x={sticker.x}
             y={sticker.y}
             scale={sticker.scale}
+            rotation={sticker.rotation}
             isSelected={selectedId === sticker.id}
             onSelect={setSelectedId}
           />

--- a/components/ui/common/editorCanvas/drawingToolbar.tsx
+++ b/components/ui/common/editorCanvas/drawingToolbar.tsx
@@ -6,6 +6,12 @@ import styled from "styled-components/native";
 
 const COLORS = ["hotpink", "red", "blue", "black", "orange"];
 
+const SPECIAL_PENS = [
+  { id: "glitter", label: "✨", bg: "#FF1493" },
+  { id: "neon", label: "💡", bg: "#00FFFF" },
+  { id: "rainbow", label: "🌈", bg: "#9370DB" },
+];
+
 const BottomBar = styled.View`
   position: absolute;
   bottom: 0px;
@@ -37,6 +43,24 @@ const ColorButton = styled.TouchableOpacity<{ selected: boolean; bg: string }>`
   background-color: ${(props) => props.bg};
   border-width: ${(props) => (props.selected ? 2 : 0)}px;
   border-color: white;
+`;
+
+const SpecialButton = styled.TouchableOpacity<{
+  selected: boolean;
+  bg: string;
+}>`
+  width: 30px;
+  height: 30px;
+  border-radius: 15px;
+  background-color: ${(props) => props.bg};
+  border-width: ${(props) => (props.selected ? 2 : 0)}px;
+  border-color: white;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ButtonEmoji = styled.Text`
+  font-size: 14px;
 `;
 
 const ControlIcon = styled.TouchableOpacity`
@@ -94,6 +118,16 @@ export const DrawingToolbar = ({
             selected={currentColor === color}
             onPress={() => onChangeColor(color)}
           />
+        ))}
+        {SPECIAL_PENS.map((pen) => (
+          <SpecialButton
+            key={pen.id}
+            bg={pen.bg}
+            selected={currentColor === pen.id}
+            onPress={() => onChangeColor(pen.id)}
+          >
+            <ButtonEmoji>{pen.label}</ButtonEmoji>
+          </SpecialButton>
         ))}
       </Palette>
 

--- a/components/ui/common/editorCanvas/filterLayer.tsx
+++ b/components/ui/common/editorCanvas/filterLayer.tsx
@@ -1,6 +1,8 @@
 // components/editorCanvas/filterLayer.tsx
 import { useEditorStore } from "@/store/useEditorStore";
+import { LinearGradient } from "expo-linear-gradient";
 import React from "react";
+import { View } from "react-native";
 import styled from "styled-components/native";
 
 const FilterImage = styled.Image`
@@ -14,5 +16,41 @@ const FilterImage = styled.Image`
 
 export function FilterLayer() {
   const filter = useEditorStore((state) => state.filter);
-  return filter ? <FilterImage source={filter} testID="filter-image"/> : null;
+  if (!filter) return null;
+
+  if ("source" in filter) {
+    return <FilterImage source={filter.source} testID="filter-image" />;
+  }
+
+  if (filter.type === "solid") {
+    return (
+      <View
+        testID="filter-solid"
+        pointerEvents="none"
+        style={{
+          position: "absolute",
+          width: "100%",
+          height: "100%",
+          backgroundColor: filter.color,
+          opacity: filter.opacity,
+        }}
+      />
+    );
+  }
+
+  return (
+    <LinearGradient
+      testID="filter-gradient"
+      colors={filter.colors}
+      start={filter.start ?? { x: 0, y: 0 }}
+      end={filter.end ?? { x: 0, y: 1 }}
+      pointerEvents="none"
+      style={{
+        position: "absolute",
+        width: "100%",
+        height: "100%",
+        opacity: filter.opacity,
+      }}
+    />
+  );
 }

--- a/components/ui/common/editorCanvas/index.tsx
+++ b/components/ui/common/editorCanvas/index.tsx
@@ -14,7 +14,7 @@ import { StickerLayer } from "./StickerLayer";
 
 const CanvasWrapper = styled.View`
   flex: 1;
-  margin-top: 100px;
+  margin-top: 10px;
   align-items: center;
 `;
 const InnerArea = styled.View`
@@ -64,6 +64,7 @@ export default function EditorCanvas({
   sheetType: string;
 }) {
   const imageUri = useImageStore((state) => state.imageUri);
+  const resetVersion = useEditorStore((state) => state.resetVersion);
   const viewShotRef = useRef(null);
   const drawingLayerRef = useRef<{ undo: () => void; clear: () => void }>(null);
   const [aspectRatio, setAspectRatio] = useState(2 / 3);
@@ -84,6 +85,12 @@ export default function EditorCanvas({
       );
     }
   }, [imageUri]);
+
+  useEffect(() => {
+    if (resetVersion > 0) {
+      drawingLayerRef.current?.clear();
+    }
+  }, [resetVersion]);
 
   useEffect(() => {
     if (isSave) {
@@ -132,7 +139,7 @@ export default function EditorCanvas({
   };
   const resetEditor = () => {
     useEditorStore.getState().clearStickers();
-    useEditorStore.getState().setFilter("");
+    useEditorStore.getState().setFilter(null);
     useEditorStore.getState().setBackgroundUri("");
     drawingLayerRef.current?.clear();
     forceUpdate();

--- a/components/ui/common/modal.tsx
+++ b/components/ui/common/modal.tsx
@@ -1,33 +1,79 @@
-import React from "react";
-import { Animated, Dimensions } from "react-native";
+import React, { useEffect } from "react";
+import { Dimensions, Pressable } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
 import styled from "styled-components/native";
 
 interface BottomSheetProps {
   visible: boolean;
   height?: number;
+  onClose?: () => void;
   children: React.ReactNode;
 }
 
 const SCREEN_HEIGHT = Dimensions.get("window").height;
+
+const Backdrop = styled(Animated.View)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.25);
+  z-index: 998;
+`;
 
 const SheetContainer = styled(Animated.View)`
   position: absolute;
   left: 0;
   right: 0;
   bottom: 0;
-  background-color:#1a1a1a;
+  background-color: #1a1a1a;
   overflow: hidden;
   z-index: 999;
   padding-top: 5px;
-  pdding-bottom: 5px;
+  padding-bottom: 5px;
 `;
 
 export function BottomSheetModal({
   visible,
-  height = SCREEN_HEIGHT * 0.1,
+  height = 320,
+  onClose,
   children,
 }: BottomSheetProps) {
+  const translateY = useSharedValue(height);
+  const backdropOpacity = useSharedValue(0);
+
+  useEffect(() => {
+    translateY.value = withTiming(visible ? 0 : height, { duration: 280 });
+    backdropOpacity.value = withTiming(visible ? 1 : 0, { duration: 280 });
+  }, [visible, height]);
+
+  const sheetStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+  }));
+
+  const backdropStyle = useAnimatedStyle(() => ({
+    opacity: backdropOpacity.value,
+  }));
+
   return (
-    visible && <SheetContainer style={{ height }}>{children}</SheetContainer>
+    <>
+      <Backdrop
+        style={backdropStyle}
+        pointerEvents={visible ? "auto" : "none"}
+      >
+        <Pressable onPress={onClose} style={{ flex: 1 }} />
+      </Backdrop>
+      <SheetContainer
+        style={[{ height }, sheetStyle]}
+        pointerEvents={visible ? "auto" : "none"}
+      >
+        {children}
+      </SheetContainer>
+    </>
   );
 }

--- a/components/ui/home/home.tsx
+++ b/components/ui/home/home.tsx
@@ -1,7 +1,9 @@
+import { useEditorStore } from "@/store/useEditorStore";
 import { useImageStore } from "@/store/useImageStore";
 import Constants from "expo-constants";
 import * as ImagePicker from "expo-image-picker";
-import { useRouter } from "expo-router";
+import { useFocusEffect, useRouter } from "expo-router";
+import { useCallback } from "react";
 import styled from "styled-components/native";
 import ActionButtons from "./buttonContainer";
 import Logo from "./logo";
@@ -29,6 +31,13 @@ const VersionText = styled.Text`
 export default function HomeContainer() {
   const router = useRouter();
   const setImageUri = useImageStore((state) => state.setImageUri);
+  const resetEditor = useEditorStore((state) => state.resetEditor);
+
+  useFocusEffect(
+    useCallback(() => {
+      resetEditor();
+    }, [resetEditor])
+  );
 
   const handleTakePhoto = async () => {
     const { status } = await ImagePicker.requestCameraPermissionsAsync();

--- a/components/ui/main/main.tsx
+++ b/components/ui/main/main.tsx
@@ -1,11 +1,21 @@
 import { useEditorStore } from "@/store/useEditorStore";
+import { LinearGradient } from "expo-linear-gradient";
 import { useLayoutEffect, useRef, useState } from "react";
-import { FlatList, Image, TouchableOpacity } from "react-native";
+import { FlatList, Image, TouchableOpacity, View } from "react-native";
+import {
+  BannerAd,
+  BannerAdSize,
+  TestIds,
+} from "react-native-google-mobile-ads";
 import styled from "styled-components/native";
 import EditorCanvas from "../common/editorCanvas";
 import { BottomSheetModal } from "../common/modal";
 import TabBar from "./tabBar";
 import { bgs, filters, stickers } from "./utils/images";
+
+const bannerAdUnitId = __DEV__
+  ? TestIds.BANNER
+  : "ca-app-pub-5067038499285963/0000000000";
 
 const Container = styled.View`
   flex: 1;
@@ -15,6 +25,7 @@ const Container = styled.View`
 export const ContentArea = styled.ImageBackground`
   flex: 1;
   width: 100%;
+  overflow: hidden;
 `;
 const LogoImageContainer = styled.View`
   position: absolute;
@@ -71,6 +82,10 @@ export default function EditorScreen() {
     const isSheetType = ["background", "sticker", "filter"].includes(type);
 
     if (isSheetType) {
+      if (showSheet && sheetType === type) {
+        setShowSheet(false);
+        return;
+      }
       setShowSheet(true);
       setSheetType(type);
       setPentoolVisible(false);
@@ -122,41 +137,85 @@ export default function EditorScreen() {
     } else if (sheetType === "sticker") {
       addSticker(item.source);
     } else if (sheetType === "filter") {
-      setFilter(item.source);
+      setFilter(item);
     }
   };
 
   return (
     <Container>
+      <View
+        style={{
+          alignItems: "center",
+          paddingTop: 24,
+          backgroundColor: "transparent",
+        }}
+      >
+        <BannerAd
+          unitId={bannerAdUnitId}
+          size={BannerAdSize.ANCHORED_ADAPTIVE_BANNER}
+        />
+      </View>
       <ContentArea
         source={require("../../../assets/images/common/main/bg/main_bg.jpg")}
         resizeMode="cover"
       >
-        <BottomSheetModal visible={showSheet}>
+        <BottomSheetModal
+          visible={showSheet}
+          height={320}
+          onClose={() => setShowSheet(false)}
+        >
           <FlatList
-            horizontal
+            key="grid-4"
             ref={flatListRef}
             data={sheetItems}
             keyExtractor={(item) => item.id}
-            renderItem={({ item }) => (
-              <TouchableOpacity onPress={() => handleSelectItem(item)}>
-                <Image
-                  testID={`${item.label}`}
-                  source={item.source}
-                  style={{
-                    width: 80,
-                    height: 80,
-                    marginHorizontal: 8,
-                    resizeMode: "contain",
-                  }}
-                />
-              </TouchableOpacity>
-            )}
+            numColumns={4}
+            columnWrapperStyle={{ justifyContent: "space-between" }}
+            renderItem={({ item }) => {
+              const previewSize = {
+                width: 70,
+                height: 70,
+                margin: 6,
+                borderRadius: 8,
+              };
+              return (
+                <TouchableOpacity onPress={() => handleSelectItem(item)}>
+                  {"source" in item ? (
+                    <Image
+                      testID={`${item.label}`}
+                      source={item.source}
+                      style={{ ...previewSize, resizeMode: "contain" }}
+                    />
+                  ) : item.type === "solid" ? (
+                    <View
+                      testID={`${item.label}`}
+                      style={{
+                        ...previewSize,
+                        backgroundColor: item.color,
+                      }}
+                    />
+                  ) : (
+                    <LinearGradient
+                      testID={`${item.label}`}
+                      colors={item.colors}
+                      start={item.start ?? { x: 0, y: 0 }}
+                      end={item.end ?? { x: 0, y: 1 }}
+                      style={previewSize}
+                    />
+                  )}
+                </TouchableOpacity>
+              );
+            }}
             onEndReached={() => loadMoreItems()}
             onEndReachedThreshold={0.5}
-            showsHorizontalScrollIndicator={false}
+            showsVerticalScrollIndicator={false}
           />
         </BottomSheetModal>
+        <LogoImageContainer>
+          <LogoImage
+            source={require("../../../assets/images/common/icon.png")}
+          />
+        </LogoImageContainer>
         <EditorCanvas
           pentoolVisible={pentoolVisible}
           onPentoolClose={closePentool}
@@ -164,11 +223,6 @@ export default function EditorScreen() {
           onSaveComplete={() => setIsSave(false)}
           sheetType={sheetType}
         />
-        <LogoImageContainer>
-          <LogoImage
-            source={require("../../../assets/images/common/icon.png")}
-          />
-        </LogoImageContainer>
       </ContentArea>
       <TabBar onOpenModal={handleOpenSheet} />
     </Container>

--- a/components/ui/main/utils/images.ts
+++ b/components/ui/main/utils/images.ts
@@ -674,7 +674,26 @@ export const bgs = [
   },
 ];
 
-export const filters = [
+export type ImageFilter = { id: string; label: string; source: any };
+export type SolidFilter = {
+  id: string;
+  label: string;
+  type: "solid";
+  color: string;
+  opacity: number;
+};
+export type GradientFilter = {
+  id: string;
+  label: string;
+  type: "gradient";
+  colors: [string, string, ...string[]];
+  start?: { x: number; y: number };
+  end?: { x: number; y: number };
+  opacity: number;
+};
+export type FilterItem = ImageFilter | SolidFilter | GradientFilter;
+
+export const filters: FilterItem[] = [
   {
     id: "f1",
     label: "핑크",
@@ -700,4 +719,36 @@ export const filters = [
     label: "살색",
     source: require("../../../../assets/images/common/filter/5.png"),
   },
+  {
+    id: "f6",
+    label: "Sunset",
+    type: "gradient",
+    colors: ["#FFB088", "#FF6B9D"],
+    opacity: 0.35,
+  },
+  { id: "f7", label: "Mint", type: "solid", color: "#A0E5E5", opacity: 0.25 },
+  {
+    id: "f8",
+    label: "Y2K",
+    type: "gradient",
+    colors: ["#FF6BA9", "#6BC4E5"],
+    start: { x: 0, y: 0 },
+    end: { x: 1, y: 1 },
+    opacity: 0.3,
+  },
+  {
+    id: "f9",
+    label: "Vintage",
+    type: "solid",
+    color: "#D4B896",
+    opacity: 0.4,
+  },
+  {
+    id: "f10",
+    label: "Lavender",
+    type: "gradient",
+    colors: ["#C8A8E9", "#FFB8D9"],
+    opacity: 0.3,
+  },
+  { id: "f11", label: "Moody", type: "solid", color: "#5570AA", opacity: 0.3 },
 ];

--- a/package.json
+++ b/package.json
@@ -42,14 +42,16 @@
     "react-dom": "19.0.0",
     "react-native": "0.79.3",
     "react-native-gesture-handler": "~2.24.0",
+    "react-native-google-mobile-ads": "^14.11.0",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-svg": "15.11.2",
     "react-native-view-shot": "4.0.3",
+    "react-native-web": "^0.20.0",
     "styled-components": "^6.1.18",
     "zustand": "^5.0.5",
-    "react-native-web": "^0.20.0"
+    "expo-linear-gradient": "~14.1.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
@@ -58,6 +60,7 @@
     "@testing-library/react-native": "^13.2.0",
     "@types/jest": "^29.5.14",
     "@types/react": "~19.0.10",
+    "@types/react-native": "^0.73.0",
     "@types/react-test-renderer": "^19.0.0",
     "babel-jest": "^30.0.0-beta.3",
     "eas-cli": "^16.6.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "purikura",
   "main": "expo-router/entry",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",

--- a/store/useEditorStore.ts
+++ b/store/useEditorStore.ts
@@ -1,6 +1,7 @@
 // store/useEditorStore.ts
 import { ImageSourcePropType } from "react-native";
 import { create } from "zustand";
+import type { FilterItem } from "@/components/ui/main/utils/images";
 
 export type Sticker = {
   id: string;
@@ -8,22 +9,26 @@ export type Sticker = {
   x: number;
   y: number;
   scale: number;
+  rotation: number;
 };
 
 interface EditorState {
   imageUri: string | null;
   backgroundUri: string | null;
   stickers: Sticker[];
-  filter: string | null;
+  filter: FilterItem | null;
+  resetVersion: number;
 
   setImageUri: (uri: string) => void;
   setBackgroundUri: (uri: string) => void;
   addSticker: (source: ImageSourcePropType) => void;
   updateStickerPosition: (id: string, x: number, y: number) => void;
   updateStickerScale: (id: string, scale: number) => void;
+  updateStickerRotation: (id: string, rotation: number) => void;
   removeSticker: (id: string) => void;
-  setFilter: (filter: string | null) => void; 
-  clearStickers: () => void; 
+  setFilter: (filter: FilterItem | null) => void;
+  clearStickers: () => void;
+  resetEditor: () => void;
 }
 
 export const useEditorStore = create<EditorState>((set) => ({
@@ -31,6 +36,7 @@ export const useEditorStore = create<EditorState>((set) => ({
   backgroundUri: null,
   stickers: [],
   filter: null,
+  resetVersion: 0,
 
   setImageUri: (uri) => set({ imageUri: uri }),
   setBackgroundUri: (uri) => set({ backgroundUri: uri }),
@@ -44,6 +50,7 @@ export const useEditorStore = create<EditorState>((set) => ({
           x: 100,
           y: 100,
           scale: 1,
+          rotation: 0,
         },
       ],
     })),
@@ -56,9 +63,22 @@ export const useEditorStore = create<EditorState>((set) => ({
     set((state) => ({
       stickers: state.stickers.map((s) => (s.id === id ? { ...s, scale } : s)),
     })),
+  updateStickerRotation: (id, rotation) =>
+    set((state) => ({
+      stickers: state.stickers.map((s) =>
+        s.id === id ? { ...s, rotation } : s
+      ),
+    })),
   removeSticker: (id) =>
     set((state) => ({
       stickers: state.stickers.filter((s) => s.id !== id),
     })),
   setFilter: (filter) => set({ filter }),
+  resetEditor: () =>
+    set((state) => ({
+      stickers: [],
+      filter: null,
+      backgroundUri: null,
+      resetVersion: state.resetVersion + 1,
+    })),
 }));


### PR DESCRIPTION
## 📦 v1.2.0 업데이트 내역

작업 기간: 2026-04-30 ~ 2026-05-01
브랜치: `add/#29`
커밋: `2090004`, `359a9be`, `10af7e3`

---

### 🎉 신규 기능

#### 1. 누끼 따기 (배경 제거)
- bridge 화면에 ✨ 요술봉 아이콘 추가
- remove.bg API 연동 (`react-native-google-mobile-ads` 14.11.0)
- dev: preview(0.25MP, 무료 무제한) / prod: auto(풀해상도, 50회/월)
- 실패 시 사용자 친화 메시지

#### 2. AdMob 배너 광고
- 메인 화면 상단에 anchored adaptive banner 배치
- dev: `TestIds.BANNER` (자가 클릭 안전)
- prod: 본인 광고 단위 ID (Play Console 인증 후 정상 노출)

#### 3. 펜툴 특수 효과 3종
| 펜 | 식별자 | 효과 |
|---|---|---|
| 글리터 ✨ | `glitter` | 무지갯빛 그라데이션 + sparkle 점들 |
| 네온 💡 | `neon` | 시안 후광 3겹 + 흰색 코어 |
| 무지개 🌈 | `rainbow` | 7색 대각선 그라데이션 |

#### 4. 트렌디 SNS 필터 6종 추가
기존 5개 PNG 필터 유지, 코드 기반으로 6개 추가 (하이브리드):
- Sunset 🌅 (gradient peach→pink)
- Mint 🧊 (solid)
- Y2K 💗 (gradient pink/cyan diagonal)
- Vintage 📷 (sepia)
- Lavender 💜 (gradient purple→pink)
- Moody 🌃 (cinematic blue)

`expo-linear-gradient` 도입.

---

### 🛠 개선

#### 스티커 회전 — 각도 기반(angular) 전환
- **이전 (v1):** `dx * 0.01` — 가로 움직임만 회전에 반영, 회전된 스티커에선 어색함
- **현재 (v2):** `Math.atan2()` — 손가락이 그리는 호의 각도 변화 추적 (Photoshop 방식)
- store에 `rotation` 필드 추가로 회전값 영속화 (캡처/재선택 시 유지)
- 컨트롤 핸들 카운터 회전 — 스티커 회전과 무관하게 항상 똑바로

#### 바텀시트 모달 재설계
- 슬라이드 업/다운 애니메이션 (Reanimated, 280ms)
- 외부 클릭 닫기 (backdrop dim 0.25)
- 높이 80px → **320px**, 4열 그리드(`space-between`)
- 같은 탭 재클릭 시 토글 닫기

#### 홈 화면 복귀 시 전체 리셋
- `useFocusEffect`로 home 진입 시 `resetEditor()` 호출
- 스티커/필터/배경/펜 그림 모두 초기화
- store에 `resetVersion` 카운터 추가 → EditorCanvas가 감지해 drawing layer까지 클리어

#### 메인 레이아웃 정리
- 상단 광고 + 캔버스 위치 조정
- 로고 z-order 변경 (사진 뒤로 → 사진이 가림)
- ContentArea `overflow: hidden`으로 시트 클리핑

---

### 🐞 버그 수정

- `handleRotateDrag`: 누적 dx 폭주 (회전 과속) 수정 → 시작값 기반 절대 계산
- `handleResizeDrag`: 동일 패턴 폭주 수정
- 웹 환경에서 `react-native-view-shot`의 `findNodeHandle` 미지원 → 분기 처리
- `react-native-google-mobile-ads` v16의 RN 0.79 codegen 충돌 → v14로 다운그레이드

---

### 📦 의존성

추가:
- `react-native-google-mobile-ads@^14.11.0`
- `expo-linear-gradient@~14.1.5`
- `@types/react-native@^0.73.0` (자동 추가, 정리 대상)

---

### 🔢 버전 변경

| 필드 | 이전 | 이후 |
|---|---|---|
| `app.json` version | 1.1.2 | **1.2.0** |
| `app.json` runtimeVersion | 1.1.2 | **1.2.0** |
| `app.json` versionCode | 6 | **7** |
| `package.json` version | 1.1.2 | **1.2.0** |

신규 기능 다수, breaking change 없음 → minor bump.

---

### 📁 변경 파일 (15개, +522 -76)

```
app.json
components/ui/bridge/customCropScreen.tsx
components/ui/common/editorCanvas/DrawingLayer.tsx
components/ui/common/editorCanvas/StickerItem.tsx
components/ui/common/editorCanvas/StickerLayer.tsx
components/ui/common/editorCanvas/drawingToolbar.tsx
components/ui/common/editorCanvas/filterLayer.tsx
components/ui/common/editorCanvas/index.tsx
components/ui/common/modal.tsx
components/ui/home/home.tsx
components/ui/main/main.tsx
components/ui/main/utils/images.ts
package.json
store/useEditorStore.ts
```

---

### ⚠️ 후속 작업 / 알려진 이슈

- AdMob 콘솔 "Verify app to lift limit" → Play Console 연결로 해소 필요 (24~48h)
- `EXPO_PUBLIC_REMOVE_BG_API_KEY`는 클라이언트 번들에 박힘 → 정식 배포 전 백엔드 프록시 검토
- remove.bg 무료 50회/월 한도 → 트래픽 늘면 유료 또는 자체 호스팅(rembg) 필요
- 16KB 페이지 사이즈(Pixel 2 API 36 ps16k)에서 일부 lib 호환 모드 폴백 — 동작은 정상
- v14 → v16 업그레이드는 RN 0.81+ / 코드젠 개선 후로 보류
